### PR TITLE
fixed defaultdict not defined

### DIFF
--- a/fst.py
+++ b/fst.py
@@ -1,5 +1,6 @@
 import collections
 import collections.abc
+from collections import defaultdict
 import math
 
 EPSILON="ε" # Special symbol that is treated as the empty string


### PR DESCRIPTION
Fixed the following error: `NameError: name 'defaultdict' is not defined`